### PR TITLE
Store device nicknames/rooms etc in Domoticz instead of config.py

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -36,3 +36,4 @@ class AogState:
         self.seccode = ''
         self.tempunit = None
         self.battery = 0
+        self.ack = False


### PR DESCRIPTION
Simply put the device configuration in the Domoticz description for the device, in a section between 'voicecontrol' tags like:

```
<voicecontrol>
nicknames = Kitchen Blind One, Left Blind, Blue Blind
room = Kitchen
ack = True
</voicecontrol>
```

Other parts of the description are ignored. So you can still leave other useful descriptions.
Every variable should be on a separate line. 
If there is no such configuration in the Domoticz device it will still try the config.py to be backward compatible with existing configurations. 
This way you don't need to maintain a config.py with (potentially changing) Domoticz idx's. Nicknames and rooms can be set from a browser in the Domoticz user interface. 
To also support the 'ack' setting I have added it to the AogState object. Could not see I reason why it was not in there, but I might be overlooking something(?)

Thanks for making Google Assistant available for Domoticz! Loving it and can't wait to see how it will evolve (hopefully with some help from the community)