### PR TITLE
little BUG correction. In case Device_Config in config.yaml is empty …

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -80,6 +80,7 @@ def startServer():
             getDevices()
             getSettings()
         except (ValueError, Exception):
+            logger.error('Error in  getting devices and settings')
             pass
         # Exit if running on travis
         istravis = os.environ.get('TRAVIS') == 'true'

--- a/smarthome.py
+++ b/smarthome.py
@@ -141,7 +141,7 @@ def getDesc(state):
             desc = configuration['Scene_Config'].get(int(state.id), None)
             return desc
 
-    elif 'Device_Config' in configuration:
+    elif 'Device_Config' in configuration and configuration['Device_Config'] is not None:
         desc = configuration['Device_Config'].get(int(state.id), None)
         return desc
     else:


### PR DESCRIPTION
Correction of little bug. In case Device_Config in config.yaml is empty, no domoticz devices are loaded. Daemon is starting and showing  "Check configuration. Connection to Domoticz refused! Check configuration." in the web interface. 

Additionality in __main__.py added line to log similar exceptions in the log file.
