### PR TITLE
Merge Temp device to Thermostat

### DIFF
--- a/config/default_config
+++ b/config/default_config
@@ -71,7 +71,9 @@ Device_Config:
     report_state: false
   345:
     room: 'Hallway'
-    actual_temp_idx: '321' #Get actual temp from device 321, works only for thermostat devices
+    actual_temp_idx: '321' # Get actual temp from device 321, works only for thermostat devices
+  456:
+    hide: true # Hide device from google assistant
     
 Scene_Config:
   3:

--- a/config/default_config
+++ b/config/default_config
@@ -69,6 +69,9 @@ Device_Config:
   234:
     room: 'Bedroom'
     report_state: false
+  345:
+    room: 'Hallway'
+    actual_temp_idx: '321' #Get actual temp from device 321, works only for thermostat devices
     
 Scene_Config:
   3:

--- a/config/default_config
+++ b/config/default_config
@@ -69,11 +69,10 @@ Device_Config:
   234:
     room: 'Bedroom'
     report_state: false
-  345:
+    hide: true
+  345: # For thermostat devices only, Bug Thermostat idx must be a number above Temp idx
     room: 'Hallway'
-    actual_temp_idx: '321' # Get actual temp from device 321, works only for thermostat devices
-  456:
-    hide: true # Hide device from google assistant
+    actual_temp_idx: '321'  
     
 Scene_Config:
   3:

--- a/const.py
+++ b/const.py
@@ -88,6 +88,7 @@ sensorDOMAIN = 'Sensor'
 doorDOMAIN = 'DoorSensor'
 selectorDOMAIN = 'Selector'
 fanDOMAIN = 'Fan'
+hiddenDOMAIN = 'Hidden'
 
 ATTRS_BRIGHTNESS = 1
 ATTRS_THERMSTATSETPOINT = 1

--- a/const.py
+++ b/const.py
@@ -430,7 +430,7 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
 
             <h5 id="C2">Device Settings</h5>
 
-            <p><small class="text-muted">Nicknames, rooms, ack, hide and report_state can be set in the Domoticz user interface. Simply put the device configuration in the device description, in a section between &lt;voicecontrol&gt; tags like:
+            <p><small class="text-muted">Nicknames, rooms, ack, hide etc. can be set in the Domoticz user interface. Simply put the device configuration in the device description, in a section between &lt;voicecontrol&gt; tags like:
             </small><br /><code>
             &lt;voicecontrol&gt;<br />
             &nbsp;&nbsp;nicknames = Kitchen Blind One, Left Blind, Blue Blind<br />
@@ -438,7 +438,6 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;ack = True<br />
             &nbsp;&nbsp;report_state = False<br />
             &nbsp;&nbsp;hide = True<br />
-            &nbsp;&nbsp;merge_temp_idx = '123'<br />
             &lt;/voicecontrol&gt;<br />
             </code>
             <small class="text-muted">Other parts of the description are ignored, so you can still leave other useful descriptions.
@@ -457,7 +456,7 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;&nbsp;&nbsp;report_state: false<br>
             &nbsp;&nbsp;<b>345:</b><br>
             &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br>
-            &nbsp;&nbsp;<b>456:</b> # For thermostat devices only<br>
+            &nbsp;&nbsp;<b>456:</b> # For thermostat devices only, Bug Thermostat idx must be a number above Temp idx<br>
             &nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
             <b>Scene_Config:</b><br>
             &nbsp;&nbsp;<b>3:</b><br>

--- a/const.py
+++ b/const.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
                     
 """Constants for Google Assistant."""
-VERSION = '1.5.11'
+VERSION = '1.6'
 PUBLIC_URL = 'https://[your public url]'
 CONFIGFILE = 'config/config.yaml'
 LOGFILE = 'dzga.log'

--- a/const.py
+++ b/const.py
@@ -430,18 +430,41 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
 
             <h5 id="C2">Device Settings</h5>
 
-            <p><small class="text-muted">Nicknames, rooms, ack and report_state can be set in the Domoticz user interface. Simply put the device configuration in the device description, in a section between &lt;voicecontrol&gt; tags like:
+            <p><small class="text-muted">Nicknames, rooms, ack, hide and report_state can be set in the Domoticz user interface. Simply put the device configuration in the device description, in a section between &lt;voicecontrol&gt; tags like:
             </small><br /><code>
             &lt;voicecontrol&gt;<br />
             &nbsp;&nbsp;nicknames = Kitchen Blind One, Left Blind, Blue Blind<br />
             &nbsp;&nbsp;room = Kitchen<br />
             &nbsp;&nbsp;ack = True<br />
-            &nbsp;&nbsp;report_state = false<br />
+            &nbsp;&nbsp;report_state = False<br />
+            &nbsp;&nbsp;hide = True<br />
+            &nbsp;&nbsp;merge_temp_idx = '123'<br />
             &lt;/voicecontrol&gt;<br />
             </code>
             <small class="text-muted">Other parts of the description are ignored, so you can still leave other useful descriptions.
             Every variable should be on a separate line.
-            If there is no such configuration in the Domoticz device it will still try the config.</small></p>
+            If there is no such configuration in the Domoticz device it will still try the config:</small><br>
+            <code><b>Device_Config:</b><br>
+            &nbsp;&nbsp;<b>123:</b><br>
+            &nbsp;&nbsp;&nbsp;&nbsp;ack: true'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;room: 'Kitchen'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;nicknames:'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- 'Kitchen Blind One'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- 'Left Blind'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- 'Blue Blind'<br>
+            &nbsp;&nbsp;<b>243:</b><br>
+            &nbsp;&nbsp;&nbsp;&nbsp;room: 'Bedroom'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;report_state: false<br>
+            &nbsp;&nbsp;<b>345:</b><br>
+            &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br>
+            &nbsp;&nbsp;<b>456:</b> # For thermostat devices only<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
+            <b>Scene_Config:</b><br>
+            &nbsp;&nbsp;<b>3:</b><br>
+            &nbsp;&nbsp;&nbsp;&nbsp;room: 'Kitchen'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;nicknames:'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- 'Cool scene'<br>
+            </code></p>
 
             <h5 id="C3">Stream camera to chromecast</h5>
 

--- a/helpers.py
+++ b/helpers.py
@@ -206,6 +206,7 @@ class AogState:
         self.ack = False
         self.report_state = True
         self.actual_temp_idx = None
+        self.hide = False
 
 
 def uptime():

--- a/helpers.py
+++ b/helpers.py
@@ -205,6 +205,7 @@ class AogState:
         self.battery = 0
         self.ack = False
         self.report_state = True
+        self.actual_temp_idx = None
 
 
 def uptime():

--- a/login.html
+++ b/login.html
@@ -187,7 +187,7 @@ a{color:inherit;text-decoration:none}
 				<div class="hr"></div>
 				<div class="foot-lnk">
 					<a href="https://github.com/DewGew/Domoticz-Google-Assistant">Google Assistant for Domoticz on Github</a>
-                    <p class="label">Version 1.5.11</p>
+                    <p class="label">Version 1.6</p>
 				</div>
 			</div>
             </form>

--- a/smarthome.py
+++ b/smarthome.py
@@ -243,6 +243,15 @@ def getAog(device):
             aog.report_state = False
         if not report_state:
             aog.report_state = report_state
+        if climateDOMAIN == aog.domain:
+            at_idx = desc.get('actual_temp_idx', None)
+            if at_idx is not None:
+                aog.actual_temp_idx = at_idx
+                try:
+                    logger.info('Merge Temp%s device to %s', at_idx, aog.entity_id)
+                    aog.state = aogDevs[tempDOMAIN + at_idx].state
+                except:
+                    logger.error('Cant find device Temp%s check configuration', at_idx)
     if aog.domain == cameraDOMAIN:
         aog.report_state = False
     return aog

--- a/smarthome.py
+++ b/smarthome.py
@@ -251,7 +251,8 @@ def getAog(device):
                     aog.state = str(aogDevs[tempDOMAIN + at_idx].temp)
                     aogDevs[tempDOMAIN + at_idx].domain = hiddenDOMAIN
                 except:
-                    logger.error('Cant find temp device with idx %s', at_idx)
+                    logger.error('Merge Error, Cant find temp device with idx %s', at_idx)
+                    logger.error('Make sure temp device has a idx below %s', aog.id)
         hide = desc.get('hide', False)
         if hide:
             aog.domain = hiddenDOMAIN

--- a/smarthome.py
+++ b/smarthome.py
@@ -291,7 +291,12 @@ def getDevices(devices="all", idx="0"):
             req[aog.name]['idx'] = int(aog.id)
             req[aog.name]['type'] = aog.domain
             req[aog.name]['state'] = aog.state
-            req[aog.name]['nicknames'] = aog.nicknames
+            if aog.nicknames is not None:
+                req[aog.name]['nicknames'] = aog.nicknames
+            if aog.actual_temp_idx is not None:
+                req[aog.name]['actual_temp_idx'] = aog.actual_temp_idx
+            if aog.hide is not False:
+                req[aog.name]['hidden'] = aog.hide
             req[aog.name]['willReportState'] = aog.report_state
             logger.debug(json.dumps(req, indent=2, sort_keys=False, ensure_ascii=False))
 

--- a/smarthome.py
+++ b/smarthome.py
@@ -18,9 +18,9 @@ from const import (DOMOTICZ_TO_GOOGLE_TYPES, ERR_FUNCTION_NOT_SUPPORTED, ERR_PRO
                    DOMOTICZ_GET_SETTINGS_URL, DOMOTICZ_GET_ONE_DEVICE_URL, DOMOTICZ_GET_SCENES_URL, groupDOMAIN,
                    sceneDOMAIN, CONFIGFILE, LOGFILE, lightDOMAIN, switchDOMAIN, blindsDOMAIN, pushDOMAIN, climateDOMAIN,
                    tempDOMAIN, lockDOMAIN, invlockDOMAIN, colorDOMAIN, mediaDOMAIN, speakerDOMAIN, cameraDOMAIN,
-                   REQUEST_SYNC_BASE_URL,
-                   REPORT_STATE_BASE_URL, securityDOMAIN, outletDOMAIN, sensorDOMAIN, doorDOMAIN, selectorDOMAIN,
-                   fanDOMAIN, ATTRS_BRIGHTNESS, ATTRS_THERMSTATSETPOINT, ATTRS_COLOR_TEMP, ATTRS_PERCENTAGE, VERSION)
+                   REQUEST_SYNC_BASE_URL, REPORT_STATE_BASE_URL, securityDOMAIN, outletDOMAIN, sensorDOMAIN, doorDOMAIN,
+                   selectorDOMAIN, hiddenDOMAIN, fanDOMAIN, ATTRS_BRIGHTNESS, ATTRS_THERMSTATSETPOINT, ATTRS_COLOR_TEMP,
+                   ATTRS_PERCENTAGE, VERSION)
 from helpers import (configuration, readFile, saveFile, SmartHomeError, SmartHomeErrorNoChallenge, AogState, uptime,
                      getTunnelUrl, FILE_DIR, logger, ReportState, Auth, logfilepath)
 
@@ -248,12 +248,16 @@ def getAog(device):
             if at_idx is not None:
                 aog.actual_temp_idx = at_idx
                 try:
-                    logger.info('Merge Temp%s device to %s', at_idx, aog.entity_id)
-                    aog.state = aogDevs[tempDOMAIN + at_idx].temp
+                    aog.state = str(aogDevs[tempDOMAIN + at_idx].temp)
+                    aogDevs[tempDOMAIN + at_idx].domain = hiddenDOMAIN
                 except:
-                    logger.error('Cant find device Temp%s check configuration', at_idx)
+                    logger.error('Cant find temp device with idx %s', at_idx)
+        hide = desc.get('hide', False)
+        if hide:
+            aog.domain = hiddenDOMAIN
     if aog.domain == cameraDOMAIN:
         aog.report_state = False
+        
     return aog
 
 

--- a/smarthome.py
+++ b/smarthome.py
@@ -249,7 +249,7 @@ def getAog(device):
                 aog.actual_temp_idx = at_idx
                 try:
                     logger.info('Merge Temp%s device to %s', at_idx, aog.entity_id)
-                    aog.state = aogDevs[tempDOMAIN + at_idx].state
+                    aog.state = aogDevs[tempDOMAIN + at_idx].temp
                 except:
                     logger.error('Cant find device Temp%s check configuration', at_idx)
     if aog.domain == cameraDOMAIN:


### PR DESCRIPTION
- Added function to merge actual temperature from another temp device to thermostat
Add following to Device_Config in configuration or in `<voicecontrol>` in description:
`merge_temp_idx: '123'` in config.yaml
or
`merge_temp_idx = '123'` in description in domoticz

Above automaticly hides the tempdevice for Google Assistant

- Added function to hide devices from Google Assistant. But still visual in userinterface as hidden type. Add following to Device_Config in configuration or in `<voicecontrol>` in description:
`hide: true` in config.yaml
or
`hide = True` in description in domoticz

_Small bug_. Thermostat idx must be a number **above** Temp idx.

 #114 #127 #129
