### PR TITLE
Thermostat modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Domoticz-Google-Assistant delivers:
 - Stream surveillance camera to chromecast.
 - Toggle Selector switches.
 - Ngrok, instantly create a public HTTPS URL. Don't have to open any port on router and do not require a reverse proxy.
+- **NEW** Modes for thermostat
 
 Please feel free to modify it, extend and improve
 

--- a/config/default_config
+++ b/config/default_config
@@ -72,7 +72,8 @@ Device_Config:
     hide: true
   345: # For thermostat devices only, Bug Thermostat idx must be a number above Temp idx
     room: 'Hallway'
-    actual_temp_idx: '321'  
+    actual_temp_idx: '321' # Merge Actual temp from another temp device
+    selector_modes_idx: '392' # Merge Modes from selector device
     
 Scene_Config:
   3:

--- a/const.py
+++ b/const.py
@@ -438,7 +438,8 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;ack = True<br />
             &nbsp;&nbsp;report_state = False<br />
             &nbsp;&nbsp;hide = True<br />
-            &lt;/voicecontrol&gt;<br />
+            &nbsp;&nbsp;actual_temp_idx = 236</code><small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br />
+            <code>&lt;/voicecontrol&gt;<br />
             </code>
             <small class="text-muted">Other parts of the description are ignored, so you can still leave other useful descriptions.
             Every variable should be on a separate line.
@@ -456,7 +457,7 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;&nbsp;&nbsp;report_state: false<br>
             &nbsp;&nbsp;<b>345:</b><br>
             &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br>
-            &nbsp;&nbsp;<b>456:</b></code><small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br><br>
+            &nbsp;&nbsp;<b>456:</b></code><small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br>
             <code>&nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
             &nbsp;&nbsp;&nbsp;&nbsp;selector_modes_idx: '234'<br>
             <b>Scene_Config:</b><br>

--- a/const.py
+++ b/const.py
@@ -455,8 +455,9 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;&nbsp;&nbsp;room: 'Bedroom'<br>
             &nbsp;&nbsp;&nbsp;&nbsp;report_state: false<br>
             &nbsp;&nbsp;<b>345:</b><br>
-            &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br>
-            &nbsp;&nbsp;<b>456:</b> # For thermostat devices only, Bug Thermostat idx must be a number above Temp idx.<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br></code>
+            <small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br>
+            <code>&nbsp;&nbsp;<b>456:</b><br>
             &nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
             &nbsp;&nbsp;&nbsp;&nbsp;selector_modes_idx: '234'<br>
             <b>Scene_Config:</b><br>

--- a/const.py
+++ b/const.py
@@ -455,10 +455,9 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;&nbsp;&nbsp;room: 'Bedroom'<br>
             &nbsp;&nbsp;&nbsp;&nbsp;report_state: false<br>
             &nbsp;&nbsp;<b>345:</b><br>
-            &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br></code>
-            <small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br>
-            <code>&nbsp;&nbsp;<b>456:</b><br>
-            &nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br>
+            &nbsp;&nbsp;<b>456:</b></code><small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br><br>
+            <code>&nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
             &nbsp;&nbsp;&nbsp;&nbsp;selector_modes_idx: '234'<br>
             <b>Scene_Config:</b><br>
             &nbsp;&nbsp;<b>3:</b><br>

--- a/const.py
+++ b/const.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
                     
 """Constants for Google Assistant."""
-VERSION = '1.6'
+VERSION = '1.6.2'
 PUBLIC_URL = 'https://[your public url]'
 CONFIGFILE = 'config/config.yaml'
 LOGFILE = 'dzga.log'
@@ -456,8 +456,9 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;&nbsp;&nbsp;report_state: false<br>
             &nbsp;&nbsp;<b>345:</b><br>
             &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br>
-            &nbsp;&nbsp;<b>456:</b> # For thermostat devices only, Bug Thermostat idx must be a number above Temp idx<br>
+            &nbsp;&nbsp;<b>456:</b> # For thermostat devices only, Bug Thermostat idx must be a number above Temp idx.<br>
             &nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;selector_modes_idx: '234'<br>
             <b>Scene_Config:</b><br>
             &nbsp;&nbsp;<b>3:</b><br>
             &nbsp;&nbsp;&nbsp;&nbsp;room: 'Kitchen'<br>

--- a/const.py
+++ b/const.py
@@ -216,8 +216,8 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
                     <li>Two-factor authentication pin for domoticz protected devices (limited language support)</li>
                     <li>Acknowledgement with Yes or No. (limited language support)</li>
                     <li>Arm Disarm Securitypanel (limited language support)</li>
-                    <li>On/Off, Brightness, Thermostat, Color Settings, speaker volume, Lock/Unlock, Scene, Open/Close, Stream Camera and Toggle selector devices</li>
-                    <li>Ngrok, instantly create a public HTTPS URL. Don't have to open any port on router and do not require a reverse proxy</li>
+                    <li>Supports Ngrok and SSL</li>
+                    <li><b>NEW:</b>Modes for thermostat</li>
                 </ul>
                 <p class="lead">Please feel free to modify, extend and improve it!</p>
                 <p class="lead">
@@ -431,15 +431,15 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             <h5 id="C2">Device Settings</h5>
 
             <p><small class="text-muted">Nicknames, rooms, ack, hide etc. can be set in the Domoticz user interface. Simply put the device configuration in the device description, in a section between &lt;voicecontrol&gt; tags like:
-            </small><br /><code>
+            </small><br />
+            <code>
             &lt;voicecontrol&gt;<br />
             &nbsp;&nbsp;nicknames = Kitchen Blind One, Left Blind, Blue Blind<br />
             &nbsp;&nbsp;room = Kitchen<br />
             &nbsp;&nbsp;ack = True<br />
             &nbsp;&nbsp;report_state = False<br />
             &nbsp;&nbsp;hide = True<br />
-            &nbsp;&nbsp;actual_temp_idx = 236</code><small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br />
-            <code>&lt;/voicecontrol&gt;<br />
+            &lt;/voicecontrol&gt;<br />
             </code>
             <small class="text-muted">Other parts of the description are ignored, so you can still leave other useful descriptions.
             Every variable should be on a separate line.
@@ -457,15 +457,27 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;&nbsp;&nbsp;report_state: false<br>
             &nbsp;&nbsp;<b>345:</b><br>
             &nbsp;&nbsp;&nbsp;&nbsp;hide: true<br>
-            &nbsp;&nbsp;<b>456:</b></code><small class="text-muted">#For thermostat devices only, Bug Thermostat idx must be a number above Temp idx. Merged device will automaticly hidden</small><br>
-            <code>&nbsp;&nbsp;&nbsp;&nbsp;merge_temp_idx: '123'<br>
-            &nbsp;&nbsp;&nbsp;&nbsp;selector_modes_idx: '234'<br>
             <b>Scene_Config:</b><br>
             &nbsp;&nbsp;<b>3:</b><br>
             &nbsp;&nbsp;&nbsp;&nbsp;room: 'Kitchen'<br>
             &nbsp;&nbsp;&nbsp;&nbsp;nicknames:'<br>
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- 'Cool scene'<br>
-            </code></p>
+            </code>
+            <small class="text-muted"><b>For thermostat devices only.</b><br> Function to merge actual temperature from another temp device or modes from selector device to thermostat. Bug Thermostat idx <b>must</b> be a number <b>above</b> Temp/selector idx. Merged device will automaticly hidden. Levels from selector device supported is: Off - Heat - Cool - Auto - Eco</small><br>
+            <code>
+            &lt;voicecontrol&gt;<br />
+            &nbsp;&nbsp;actual_temp_idx = 123<br />
+            &nbsp;&nbsp;selector_modes_idx = 234<br />
+            &lt;/voicecontrol&gt;<br />
+            </code>
+            <small class="text-muted">or in config.yaml:</small><br>
+            <code><b>Device_Config:</b><br>
+            &nbsp;&nbsp;<b>456:</b></code><br>
+            <code>&nbsp;&nbsp;&nbsp;&nbsp;actual_temp_idx: '123'<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;selector_modes_idx: '234'<br>
+            </code>
+            
+            </p>
 
             <h5 id="C3">Stream camera to chromecast</h5>
 

--- a/helpers.py
+++ b/helpers.py
@@ -207,6 +207,7 @@ class AogState:
         self.report_state = True
         self.actual_temp_idx = None
         self.hide = False
+        self.modes_idx = None
 
 
 def uptime():

--- a/smarthome.py
+++ b/smarthome.py
@@ -262,7 +262,7 @@ def getAog(device):
         hide = desc.get('hide', False)
         if hide:
             aog.domain = hiddenDOMAIN
-    if aog.domain == cameraDOMAIN:
+    if aog.domain == cameraDOMAIN or aog.domain == selectorDOMAIN:
         aog.report_state = False
         
     return aog
@@ -775,7 +775,7 @@ class SmartHomeReqHandler(OAuthReqHandler):
         
         for device in payload.get('devices', []):
             devid = device['id']
-            _GoogleEntity(aogDevs.get(devid, None)).async_update()
+            #_GoogleEntity(aogDevs.get(devid, None)).async_update()
             state = aogDevs.get(devid, None)           
             if not state:
                 # If we can't find a state, the device is offline
@@ -830,7 +830,6 @@ class SmartHomeReqHandler(OAuthReqHandler):
                     logger.error(err)
 
         final_results = list(results.values())
-
         for entity in entities.values():
             if entity.entity_id in results:
                 continue
@@ -844,8 +843,8 @@ class SmartHomeReqHandler(OAuthReqHandler):
                 except:
                     continue
 
-        if state.report_state == True and enableReport == True:
-            self.report_state(states, token)
+            if state.report_state == True and enableReport == True:
+                self.report_state(states, token)
 
         return {'commands': final_results}
 

--- a/trait.py
+++ b/trait.py
@@ -385,15 +385,18 @@ class TemperatureSettingTrait(_Trait):
         domain = self.state.domain
         units = self.state.tempunit
         response = {"thermostatTemperatureUnit": _google_temp_unit(units)}
-        response["thermostatTemperatureRange"] = {
-            'minThresholdCelsius': 5,
-            'maxThresholdCelsius': 35}
+        # response["thermostatTemperatureRange"] = {
+            # 'minThresholdCelsius': 5,
+            # 'maxThresholdCelsius': 35}
         
         if domain == tempDOMAIN:
             response["queryOnlyTemperatureSetting"] = True
 
         elif domain == climateDOMAIN:
-            response["availableThermostatModes"] = 'off,heat,cool,auto,eco'
+            if self.state.modes_idx is not None:
+                response["availableThermostatModes"] = 'off,heat,cool,auto,eco'
+            else:
+                response["availableThermostatModes"] = 'heat'
 
         return response
 

--- a/trait.py
+++ b/trait.py
@@ -438,14 +438,18 @@ class TemperatureSettingTrait(_Trait):
     def execute(self, command, params):
         """Execute a temperature point or mode command."""
         # All sent in temperatures are always in Celsius
-        if command == COMMAND_THERMOSTAT_SET_MODE and self.state.modes_idx is not None:
-            levels = base64.b64decode(self.state.selectorLevelName).decode('UTF-8').split("|")
-            levelName = [x.lower() for x in levels]
+        if command == COMMAND_THERMOSTAT_SET_MODE:
+            if self.state.modes_idx is not None:
+                levels = base64.b64decode(self.state.selectorLevelName).decode('UTF-8').split("|")
+                levelName = [x.lower() for x in levels]
 
-            if params['thermostatMode'] in levelName:
-                level = str(levelName.index(params['thermostatMode']) * 10)
-            url = DOMOTICZ_URL + '/json.htm?type=command&param=switchlight&idx=' + self.state.modes_idx + '&switchcmd=Set%20Level&level=' + level
-            r = requests.get(url, auth=(configuration['Domoticz']['username'], configuration['Domoticz']['password']))
+                if params['thermostatMode'] in levelName:
+                    level = str(levelName.index(params['thermostatMode']) * 10)
+                url = DOMOTICZ_URL + '/json.htm?type=command&param=switchlight&idx=' + self.state.modes_idx + '&switchcmd=Set%20Level&level=' + level
+                r = requests.get(url, auth=(configuration['Domoticz']['username'], configuration['Domoticz']['password']))
+            else:
+                raise SmartHomeError('notSupported',
+                                     'Unable to execute {} for {} check your settings'.format(command, self.state.entity_id))
                 
         if command == COMMAND_THERMOSTAT_TEMPERATURE_SETPOINT:
             if self.state.modes_idx is not None:


### PR DESCRIPTION
This PR contains:
- Fixes report_state issue when raise errors
- Merge selector device retaining the modes for thermostats, supports following levels:
   - Off - Heat - Cool - Auto - Eco
   - Automaticly hides selector device
   - _**Bug!** Selector device idx **must** to be **lower** than thermostat idx_ 

Add modes to thermostat:
 - Create selector device with levels above
 - Create thermostat device
 - In thermostat description add:
```html
<voicecontrol>
selector_modes_idx = 123
</voicecontrol>

```
or in config.yaml:
```python
Device_Config:
  234:
    selector_modes_idx = 123
```
#114