### PR TITLE
Correction in start/stop trait

### DIFF
--- a/trait.py
+++ b/trait.py
@@ -381,6 +381,7 @@ class StartStopTrait(_Trait):
 
     def query_attributes(self):
         """Return StartStop query attributes."""
+        response = {}
         if self.state.domain == domains['blinds']:
             response['isRunning'] = True
         


### PR DESCRIPTION
Correction in start/stop trait. Fix for problem when adding device using start/stop trait (ex blinds) - not initialized variable.
