### PR TITLE
Device Types

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
                     
 """Constants for Google Assistant."""
-VERSION = '1.7.0'
+VERSION = '1.7.1'
 PUBLIC_URL = 'https://[your public url]'
 CONFIGFILE = 'config/config.yaml'
 LOGFILE = 'dzga.log'
@@ -269,7 +269,7 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
                     <li>Acknowledgement with Yes or No. (limited language support)</li>
                     <li>Arm Disarm Securitypanel (limited language support)</li>
                     <li>Supports Ngrok and SSL</li>
-                    <li><b>NEW:</b>Modes for thermostat</li>
+                    <li><b class="text-danger">NEW:</b> <i class="text-info">Function to change device type, icon and some behavior depending on the device.</i></li>
                 </ul>
                 <p class="lead">Please feel free to modify, extend and improve it!</p>
                 <p class="lead">
@@ -544,6 +544,21 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
             &nbsp;&nbsp;<b>456:</b></code><br>
             <code>&nbsp;&nbsp;&nbsp;&nbsp;merge_thermo_idx: '234'<br>
             </code>
+            <small class="text-muted"><b>Device Type</b><br> Function to change device type, icon and some behavior depending on the device (e.g open/close instead of on/off).</small><br>
+            <code>
+            &lt;voicecontrol&gt;<br />
+            &nbsp;&nbsp;devicetype = oven<br />
+            &lt;/voicecontrol&gt;<br />
+            </code>
+            <small class="text-muted">or in config.yaml:</small><br>
+            <code><b>Device_Config:</b><br>
+            &nbsp;&nbsp;<b>456:</b></code><br>
+            <code>&nbsp;&nbsp;&nbsp;&nbsp;devicetype: 'oven'<br>
+            </code>
+            <small class="text-muted">Light Device types to choose from is:<br>
+            <i class="text-info">light, ac_unit, bathtub, coffemaker, dishwasher, dryer, fan, heater, kettle, media, microwave, outlet, oven, speaker, switch, vacuum, washer, waterheater, window, gate, garage.</i><br>
+            For <i class="text-info">heater, kettle, waterheater, oven</i> you can still use <code>merge_thermo_idx</code> to merge thermostat to control temperature.<br>
+            Door Contact devices can choose <i class="text-info">window, gate</i> or <i class="text-info">garage</i><br>Selector devices can choose only <i class="text-info">vacuum</i></small><br>
             
             </p>
 

--- a/const.py
+++ b/const.py
@@ -116,6 +116,7 @@ domains = {
     'thermostat': 'Thermostat',
     'valve': 'Valve',
     'vacuum': 'Vacuum',
+    'washer': 'Washer',
     'waterheater': 'Waterheater',
     'window': 'Window'
     }
@@ -165,6 +166,7 @@ DOMOTICZ_TO_GOOGLE_TYPES = {
     domains['thermostat']: TYPE_THERMOSTAT,
     domains['vacuum']: TYPE_VACUUM,
     domains['valve']: TYPE_VALVE,
+    domains['washer']: TYPE_WASHER,
     domains['waterheater']: TYPE_WATERHEATER,
     domains['window']: TYPE_WINDOW,
 }

--- a/const.py
+++ b/const.py
@@ -54,7 +54,6 @@ TYPE_SECURITY = PREFIX_TYPES + 'SECURITYSYSTEM'
 TYPE_SENSOR = PREFIX_TYPES + 'SENSOR'
 TYPE_SMOKE_DETECTOR = PREFIX_TYPES + 'SMOKE_DETECTOR'
 TYPE_SPEAKER = PREFIX_TYPES + 'SPEAKER'
-TYPE_SPRINKLER = PREFIX_TYPES + 'SPRINKLER'
 TYPE_SWITCH = PREFIX_TYPES + 'SWITCH'
 TYPE_THERMOSTAT = PREFIX_TYPES + 'THERMOSTAT'
 TYPE_VACUUM = PREFIX_TYPES + 'VACUUM'
@@ -77,24 +76,30 @@ ERR_VALUE_OUT_OF_RANGE = "valueOutOfRange"
 ERR_WRONG_PIN = 'pinIncorrect'
 
 domains = {
+    'ac_unit': 'AcUnit',
+    'bathtub': 'Bathtub',
     'blinds': 'Blinds',
     'camera': 'Camera',
-    'climate': 'Thermostat',
-    'coffe': 'Coffemaker',
+    'coffemaker': 'Coffemaker',
     'color': 'ColorSwitch',
     'cooktop': 'Cooktop',
     'door': 'DoorSensor',
+    'dishwasher': 'Dishwasher',
+    'dryer': 'Dryer',
     'fan': 'Fan',
+    'garage': 'GarageSensor',
+    'gate': 'Gate',
     'group': 'Group',
     'heater': 'Heater',
     'hidden': 'Hidden',
-    'invlock': 'DoorLock',
     'kettle': 'Kettle',
     'light': 'Light',
     'lock': 'DoorLock',
+    'lockinv': 'DoorLock',
     'media': 'Media',
     'merged': 'Merged(Idx:',
     'microwave': 'Microwave',
+    'mower': 'Mower',
     'outlet': 'Outlet',
     'oven': 'Oven',
     'push': 'Push',
@@ -104,12 +109,15 @@ domains = {
     'security': 'Security',
     'selector': 'Selector',
     'sensor': 'Sensor',
-    'smoke': 'SmokeDetektor',
+    'smokedetektor': 'SmokeDetektor',
     'speaker': 'Speaker',
     'switch': 'Switch',
-    'temp': 'Temp',
-    'mower': 'Mower',
-    'vacuum': 'Vacuum'
+    'temperature': 'Temperture',
+    'thermostat': 'Thermostat',
+    'valve': 'Valve',
+    'vacuum': 'Vacuum',
+    'waterheater': 'Waterheater',
+    'window': 'Window'
     }
 
 ATTRS_BRIGHTNESS = 1
@@ -120,21 +128,28 @@ ATTRS_PERCENTAGE = 1
 ATTRS_FANSPEED = 1
 
 DOMOTICZ_TO_GOOGLE_TYPES = {
+    domains['ac_unit']: TYPE_AC_UNIT,
+    domains['bathtub']: TYPE_BATHTUB,
     domains['blinds']: TYPE_BLINDS,
     domains['camera']: TYPE_CAMERA,
-    domains['climate']: TYPE_THERMOSTAT,
-    domains['coffe']: TYPE_COFFEE,
+    domains['coffemaker']: TYPE_COFFEE,
     domains['color']: TYPE_LIGHT,
+    domains['cooktop']: TYPE_COOKTOP,
+    domains['dishwasher']: TYPE_DISHWASHER,
     domains['door']: TYPE_DOOR,
+    domains['dryer']: TYPE_DRYER,
     domains['fan']: TYPE_FAN,
+    domains['garage']: TYPE_GARAGE,
+    domains['gate']: TYPE_GATE,
     domains['group']: TYPE_SWITCH,
     domains['heater']: TYPE_HEATER,
-    domains['invlock']: TYPE_LOCK,
     domains['kettle']: TYPE_KETTLE,
     domains['light']: TYPE_LIGHT,
     domains['lock']: TYPE_LOCK,
+    domains['lockinv']: TYPE_LOCK,
     domains['media']: TYPE_MEDIA,
     domains['microwave']: TYPE_MICRO,
+    domains['mower']: TYPE_MOWER,
     domains['outlet']: TYPE_OUTLET,
     domains['oven']: TYPE_OVEN,
     domains['push']: TYPE_SWITCH,
@@ -143,12 +158,15 @@ DOMOTICZ_TO_GOOGLE_TYPES = {
     domains['security']: TYPE_SECURITY,
     domains['selector']: TYPE_SWITCH,
     domains['sensor']: TYPE_SENSOR,
-    domains['smoke']: TYPE_SMOKE_DETECTOR,
+    domains['smokedetektor']: TYPE_SMOKE_DETECTOR,
     domains['speaker']: TYPE_SPEAKER,
     domains['switch']: TYPE_SWITCH,
-    domains['temp']: TYPE_THERMOSTAT,
-    domains['mower']: TYPE_MOWER,
+    domains['temperature']: TYPE_THERMOSTAT,
+    domains['thermostat']: TYPE_THERMOSTAT,
     domains['vacuum']: TYPE_VACUUM,
+    domains['valve']: TYPE_VALVE,
+    domains['waterheater']: TYPE_WATERHEATER,
+    domains['window']: TYPE_WINDOW,
 }
 
 TEMPLATE = """

--- a/const.py
+++ b/const.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
                     
 """Constants for Google Assistant."""
-VERSION = '1.6.5'
+VERSION = '1.7.0'
 PUBLIC_URL = 'https://[your public url]'
 CONFIGFILE = 'config/config.yaml'
 LOGFILE = 'dzga.log'
@@ -127,6 +127,7 @@ ATTRS_COLOR = 2
 ATTRS_COLOR_TEMP = 3
 ATTRS_PERCENTAGE = 1
 ATTRS_FANSPEED = 1
+ATTRS_VACCUM_MODES = 1
 
 DOMOTICZ_TO_GOOGLE_TYPES = {
     domains['ac_unit']: TYPE_AC_UNIT,

--- a/const.py
+++ b/const.py
@@ -304,12 +304,12 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
                 <i class="material-icons" style="vertical-align: middle;">timelapse</i><small class="text-muted"> Sytem Uptime:<br>{uptime}</small>
               </div>
               <div class="col">
-                <small class="text-muted">DZGA Version:<br>V""" + VERSION + """ {branch}</small><br>
-                <small class="text-muted" id="updates"></small>
+                <small class="text-muted"><b>DZGA Version:</b><br> """ + VERSION + """ {branch} <i class="text-muted; text-info" id="updates"></i><br>
+                <b>Domoticz Version:</b><br> {dzversion}</small><br><br>
+                
               </div>
               <div class="col" id="buttonUpdate"></div>
               <div class="col-4">
-                <small class="text-muted">Encourage the development.</small>
                 <form action="https://www.paypal.me/dzga" target="_blank" rel="noopener" aria-label="Paypal">
                 <button class="btn btn-raised btn-info" title="Sponsor with PayPal" alt="Sponsor with PayPal">
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="32" height="32" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg); vertical-align: middle;" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path d="M8.32 21.97a.546.546 0 0 1-.26-.32c-.03-.15-.06.11.6-4.09c.6-3.8.59-3.74.67-3.85c.13-.17.11-.17 1.61-.18c1.32-.03 1.6-.03 2.19-.12c3.25-.45 5.26-2.36 5.96-5.66c.04-.22.08-.41.09-.41c0-.01.07.04.15.1c1.03.78 1.38 2.22.99 4.14c-.46 2.29-1.68 3.81-3.58 4.46c-.81.28-1.49.39-2.69.42c-.8.04-.82.04-1.05.19c-.17.17-.16.14-.55 2.55c-.27 1.7-.37 2.25-.41 2.35c-.07.16-.21.3-.37.38l-.11.07H10c-1.29 0-1.62 0-1.68-.03m-4.5-2.23c-.19-.1-.32-.27-.32-.47C3.5 19 6.11 2.68 6.18 2.5c.09-.18.32-.37.5-.44L6.83 2h3.53c3.91 0 3.76 0 4.64.2c2.62.55 3.82 2.3 3.37 4.93c-.5 2.93-1.98 4.67-4.5 5.3c-.87.21-1.48.27-3.14.27c-1.31 0-1.41.01-1.67.15c-.26.15-.47.42-.56.75c-.04.07-.27 1.47-.53 3.1a241.3 241.3 0 0 0-.47 3.02l-.03.06H5.69c-1.58 0-1.8 0-1.87-.04z" fill="#FFF"/><rect x="0" y="0" width="24" height="24" fill="rgba(0, 0, 0, 0)" /></svg>
@@ -724,11 +724,11 @@ style=" fill:#000000;"><g fill="none" fill-rule="none" stroke="none" stroke-widt
         var updates = {update}
         document.getElementById("logsheader").innerHTML = 'Logs <br><small class="text-muted">Loglevel: ' + config.loglevel + '</small>';
         if (updates) {{
-          document.getElementById("updates").innerHTML = "Updates are Availible.";
+          document.getElementById("updates").innerHTML = "(Updates are Availible)";
           // document.getElementById("modalLabel").innerHTML = "Updates are Availible!";
           // document.getElementById("message").innerHTML = '<p>Updates are Availible. Just press update button to get latest Dzga version.</p><p><center><form action="/settings" method="post"><button class="btn btn-raised btn-primary" name="update" value="update"><i class="material-icons" style="vertical-align: middle;">update</i> Update</button></form></center></p>';
           // $('#messageModal').modal('show')
-          $('#buttonUpdate').append('<br><form action="/settings" method="post"><button class="btn btn-raised btn-primary" name="update" value="update"><i class="material-icons" style="vertical-align: middle;">update</i> Update</button></form>');
+          $('#buttonUpdate').append('<br><form action="/settings" method="post"><button class="btn btn-raised btn-primary" name="update" value="update"><i class="material-icons" style="vertical-align: middle;">update</i> Update dzga</button></form>');
         }};
 
         $('body').bootstrapMaterialDesign();

--- a/smarthome.py
+++ b/smarthome.py
@@ -299,6 +299,8 @@ def getAog(device):
         aog.attributes = ATTRS_PERCENTAGE
     if domains['blinds'] == aog.domain and "Blinds Percentage Inverted" == device["SwitchType"]:
         aog.attributes = ATTRS_PERCENTAGE
+    if domains['vacuum'] == aog.domain and "Selector" == device["SwitchType"]:
+        aog.attributes = ATTRS_VACCUM_MODES
         
     return aog
 

--- a/smarthome.py
+++ b/smarthome.py
@@ -280,8 +280,8 @@ def getAog(device):
         if hide:
             aog.domain = domains['hidden']
             
-    #if aog.domain in [domains['camera'], domains['selector'], domains['blinds'], domains['heater'], domains['kettle'], domains['bathtub']]:
-     #   aog.report_state = False
+    # if aog.domain in [domains['camera'], domains['selector'], domains['blinds'], domains['heater'], domains['kettle'], domains['bathtub']]:
+        # aog.report_state = False
         
     if domains['light'] == aog.domain and "Dimmer" == device["SwitchType"]:
         aog.attributes = ATTRS_BRIGHTNESS
@@ -682,10 +682,11 @@ class SmartHomeReqHandler(OAuthReqHandler):
         code = readFile(os.path.join(FILE_DIR, CONFIGFILE))
         logs = readFile(os.path.join(logfilepath, LOGFILE))
         template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                   conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
 
         s.send_message(200, template)
-
+    
     def settings_post(self, s):
         enableReport = ReportState.enable_report_state()
         update = checkupdate()
@@ -704,7 +705,8 @@ class SmartHomeReqHandler(OAuthReqHandler):
             logs = readFile(os.path.join(logfilepath, LOGFILE))
             code = readFile(os.path.join(FILE_DIR, CONFIGFILE))
             template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                       conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
 
             s.send_message(200, template)
 
@@ -715,7 +717,8 @@ class SmartHomeReqHandler(OAuthReqHandler):
             logger.info(message)
             logs = readFile(os.path.join(logfilepath, LOGFILE))
             template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                       conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
 
             s.send_message(200, template)
 
@@ -726,7 +729,8 @@ class SmartHomeReqHandler(OAuthReqHandler):
             logs = ''
 
             template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                       conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
 
             s.send_message(200, template)
             restartServer()
@@ -743,14 +747,16 @@ class SmartHomeReqHandler(OAuthReqHandler):
                 message = 'Add Homegraph api key or a Homegraph Service Account json file to sync devices here!'
             logs = readFile(os.path.join(logfilepath, LOGFILE))
             template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                       conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
             s.send_message(200, template)
 
         if s.form.get("reload"):
             message = ''
 
             template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                       conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
             s.send_message(200, template)
 
         if s.form.get("deletelogs"):
@@ -762,7 +768,8 @@ class SmartHomeReqHandler(OAuthReqHandler):
             message = 'Logs removed'
             logs = readFile(os.path.join(logfilepath, LOGFILE))
             template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                       conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
             s.send_message(200, template)
 
         if s.form.get("update"):
@@ -772,7 +779,8 @@ class SmartHomeReqHandler(OAuthReqHandler):
             meta = '<meta http-equiv="refresh" content="20">'
 
             template = TEMPLATE.format(message=message, uptime=uptime(), list=deviceList, meta=meta, code=code,
-                                       conf=confJSON, public_url=public_url, logs=logs, update=update, branch=repo.active_branch.name)
+                                       conf=confJSON, public_url=public_url, logs=logs, update=update,
+                                       branch=repo.active_branch.name, dzversion=settings['dzversion'])
             s.send_message(200, template)
             
             subprocess.call(['pip', 'install','-r', os.path.join(FILE_DIR, 'requirements/pip-requirements.txt')])

--- a/smarthome.py
+++ b/smarthome.py
@@ -223,7 +223,7 @@ def getAog(device):
         dt = desc.get('devicetype', None)
         if dt is not None:
             if aog.domain in [domains['light']]:
-                if dt.lower() in ['light', 'ac_unit', 'bathtub', 'coffemaker', 'dishwasher', 'dryer', 'fan', 'heater', 'kettle', 'media', 'microwave', 'outlet', 'oven', 'speaker', 'switch', 'vacuum', 'washer', 'waterheater']:
+                if dt.lower() in ['window', 'gate', 'garage', 'light', 'ac_unit', 'bathtub', 'coffemaker', 'dishwasher', 'dryer', 'fan', 'heater', 'kettle', 'media', 'microwave', 'outlet', 'oven', 'speaker', 'switch', 'vacuum', 'washer', 'waterheater']:
                     aog.domain = domains[dt.lower()]
             if aog.domain in [domains['door']]:
                 if dt.lower() in ['window', 'gate', 'garage']:
@@ -884,7 +884,7 @@ class SmartHomeReqHandler(OAuthReqHandler):
             if entity.entity_id in results:
                 continue
             entity.async_update()
-            # final_results.append({'ids': [entity.entity_id], 'status': 'SUCCESS', 'states': entity.query_serialize()})
+            #final_results.append({'ids': [entity.entity_id], 'status': 'SUCCESS', 'states': entity.query_serialize()})
             final_results.append({'ids': [entity.entity_id], 'status': 'SUCCESS', 'states': new_state})
             if state.report_state:
                 try:

--- a/smarthome.py
+++ b/smarthome.py
@@ -888,8 +888,8 @@ class SmartHomeReqHandler(OAuthReqHandler):
             final_results.append({'ids': [entity.entity_id], 'status': 'SUCCESS', 'states': new_state})
             if state.report_state:
                 try:
-                    # states[entity.entity_id] = entity.query_serialize()
-                    states[entity.entity_id] = new_state
+                    states[entity.entity_id] = entity.query_serialize()
+                    # states[entity.entity_id] = new_state
                 except:
                     continue
 

--- a/smarthome.py
+++ b/smarthome.py
@@ -280,8 +280,8 @@ def getAog(device):
         if hide:
             aog.domain = domains['hidden']
             
-    if aog.domain in [domains['camera'], domains['selector'], domains['blinds'], domains['heater'], domains['kettle'], domains['bathtub']]:
-        aog.report_state = False
+    #if aog.domain in [domains['camera'], domains['selector'], domains['blinds'], domains['heater'], domains['kettle'], domains['bathtub']]:
+     #   aog.report_state = False
         
     if domains['light'] == aog.domain and "Dimmer" == device["SwitchType"]:
         aog.attributes = ATTRS_BRIGHTNESS

--- a/trait.py
+++ b/trait.py
@@ -1161,7 +1161,7 @@ class Timer(_Trait):
 
                 r = requests.get(url, auth=CREDITS)
         else:
-            logger.error('To use Timer function you need to run Domoticz version above 4.11687')
+            logger.error('To use Timer function you need to run Domoticz version above 2020.1.11804')
             logger.error('and have dzVents Dzga_Timer script installed and active')
             raise SmartHomeError('functionNotSupported',
                                      'Unable to execute {} for {} check your settings'.format(command,

--- a/trait.py
+++ b/trait.py
@@ -6,8 +6,9 @@ from datetime import datetime
 
 import requests
 
-from const import (ATTRS_BRIGHTNESS, ATTRS_THERMSTATSETPOINT, ATTRS_COLOR, ATTRS_COLOR_TEMP, ATTRS_PERCENTAGE, domains,
-                   ERR_ALREADY_IN_STATE, ERR_WRONG_PIN, ERR_NOT_SUPPORTED, ATTRS_FANSPEED)
+from const import (ATTRS_BRIGHTNESS, ATTRS_THERMSTATSETPOINT, ATTRS_COLOR, ATTRS_COLOR_TEMP, ATTRS_PERCENTAGE,
+                   ATTRS_VACCUM_MODES, domains, ERR_ALREADY_IN_STATE, ERR_WRONG_PIN, ERR_NOT_SUPPORTED,
+                   ATTRS_FANSPEED)
 
 from helpers import SmartHomeError, configuration, logger, tempConvert
 
@@ -1020,7 +1021,10 @@ class TooglesTrait(_Trait):
     @staticmethod
     def supported(domain, features):
         """Test if state is supported."""
-        return domain in domains['selector']
+        if domain == domains['vacuum']:
+            return features & ATTRS_VACCUM_MODES
+        else:
+            return domain in domains['selector']
 
     def sync_attributes(self):
         """Return mode attributes for a sync request."""

--- a/trait.py
+++ b/trait.py
@@ -113,25 +113,36 @@ class OnOffTrait(_Trait):
     commands = [
         COMMAND_ONOFF
     ]
-
+    
     @staticmethod
     def supported(domain, features):
         """Test if state is supported."""
 
         return domain in (
-            domains['group'],
-            domains['switch'],
-            domains['light'],
+            domains['ac_unit'],
+            domains['bathtub'],
+            domains['coffemaker'],
             domains['color'],
-            domains['media'],
-            domains['outlet'],
-            domains['push'],
-            domains['speaker'],
-            domains['sensor'],
+            domains['cooktop'],
+            domains['dishwasher'],
+            domains['dryer'],
             domains['fan'],
+            domains['group'],
             domains['heater'],
-            domains['smoke'],
             domains['kettle'],
+            domains['light'],
+            domains['media'],
+            domains['microwave'],
+            domains['mower'],
+            domains['outlet'],
+            domains['oven'],
+            domains['push'],
+            domains['sensor'],
+            domains['smokedetektor'],
+            domains['speaker'],
+            domains['switch'],
+            domains['vacuum'],
+            domains['waterheater'],
         )
 
     def sync_attributes(self):
@@ -157,7 +168,7 @@ class OnOffTrait(_Trait):
         domain = self.state.domain
         protected = self.state.protected
 
-        if domain not in [domains['sensor'], domains['smoke']]:
+        if domain not in [domains['sensor'], domains['smokedetektor']]:
             if domain == domains['group']:
                 url = DOMOTICZ_URL + '/json.htm?type=command&param=switchscene&idx=' + self.state.id + '&switchcmd=' + (
                     'On' if params['on'] else 'Off')
@@ -301,7 +312,14 @@ class OpenCloseTrait(_Trait):
     @staticmethod
     def supported(domain, features):
         """Test if state is supported."""
-        return domain in [domains['blinds'], domains['door']]
+        return domain in (
+                domains['blinds'],
+                domains['door'],
+                domains['window'],
+                domains['gate'],
+                domains['garage'],
+                domains['valve']
+            )
 
     def sync_attributes(self):
         """Return OpenClose attributes for a sync request."""
@@ -381,7 +399,6 @@ class StartStopTrait(_Trait):
 
     def query_attributes(self):
         """Return StartStop query attributes."""
-        response = {}
         if self.state.domain == domains['blinds']:
             response['isRunning'] = True
         
@@ -497,10 +514,10 @@ class TemperatureSettingTrait(_Trait):
     @staticmethod
     def supported(domain, features):
         """Test if state is supported."""
-        if domain == domains['climate']:
+        if domain == domains['thermostat']:
             return features & ATTRS_THERMSTATSETPOINT
         else:
-            return domain in domains['temp']
+            return domain in domains['temperature']
 
     def sync_attributes(self):
         """Return temperature point and modes attributes for a sync request."""
@@ -511,10 +528,10 @@ class TemperatureSettingTrait(_Trait):
             'minThresholdCelsius': -20,
             'maxThresholdCelsius': 40}
         
-        if domain == domains['temp']:
+        if domain == domains['temperature']:
             response["queryOnlyTemperatureSetting"] = True
 
-        elif domain == domains['climate']:
+        elif domain == domains['thermostat']:
             if self.state.modes_idx is not None:
                 response["availableThermostatModes"] = 'off,heat,cool,auto,eco'
             else:
@@ -530,7 +547,7 @@ class TemperatureSettingTrait(_Trait):
         if self.state.battery <= configuration['Low_battery_limit']:
             response['exceptionCode'] = 'lowBattery'
 
-        if domain == domains['temp']:
+        if domain == domains['temperature']:
             response['thermostatMode'] = 'heat'
             current_temp = self.state.temp
             if current_temp is not None:
@@ -540,7 +557,7 @@ class TemperatureSettingTrait(_Trait):
             if current_humidity is not None:
                 response['thermostatHumidityAmbient'] = current_humidity
 
-        if domain == domains['climate']:
+        if domain == domains['thermostat']:
             if self.state.modes_idx is not None:
                 levelName = base64.b64decode(self.state.selectorLevelName).decode('UTF-8').split("|")
                 level = self.state.level
@@ -671,7 +688,7 @@ class LockUnlockTrait(_Trait):
     def supported(domain, features):
         """Test if state is supported."""
         return domain in (domains['lock'],
-                          domains['invlock'])
+                          domains['lockinv'])
 
     def sync_attributes(self):
         """Return LockUnlock attributes for a sync request."""
@@ -1087,12 +1104,13 @@ class Timer(_Trait):
 
     def sync_attributes(self):
         """Return Timer attributes for a sync request."""
-        return {"maxTimerLimitSec": 7200}
+        return {"maxTimerLimitSec": 7200,
+                "commandOnlyTimer": True}
 
     def query_attributes(self):
         """Return Timer query attributes."""    
         response = {}
-        # response['timerRemainingSec'] = self.state.timer
+        # response['timerRemainingSec'] = -1
         
         return response
 

--- a/trait.py
+++ b/trait.py
@@ -336,7 +336,7 @@ class OpenCloseTrait(_Trait):
         if features & ATTRS_PERCENTAGE:
             response['openPercent'] = self.state.level
         else:
-            if self.state.state == 'Open':
+            if self.state.state in ['Open', 'On']:
                 response['openPercent'] = 100
             else:
                 response['openPercent'] = 0

--- a/trait.py
+++ b/trait.py
@@ -142,6 +142,7 @@ class OnOffTrait(_Trait):
             domains['speaker'],
             domains['switch'],
             domains['vacuum'],
+            domains['washer'],
             domains['waterheater'],
         )
 
@@ -627,7 +628,7 @@ class TemperatureControlTrait(_Trait):
     @staticmethod
     def supported(domain, features):
         """Test if state is supported."""
-        return domain in [domains['heater'], domains['kettle']]
+        return domain in [domains['heater'], domains['kettle'], domains['waterheater'], domains['oven']]
 
     def sync_attributes(self):
         """Return temperature point attributes for a sync request."""

--- a/trait.py
+++ b/trait.py
@@ -336,7 +336,7 @@ class OpenCloseTrait(_Trait):
         if features & ATTRS_PERCENTAGE:
             response['openPercent'] = self.state.level
         else:
-            if self.state.state in ['Open', 'On']:
+            if self.state.state in ['Open', 'Off']:
                 response['openPercent'] = 100
             else:
                 response['openPercent'] = 0


### PR DESCRIPTION
Function to change device type, icon and some behavior depending on the device _(e.g open/close instead of on/off)_. 
For fully control remove `Image_Override` from config.
To change device type, add to discription for your device in domoticz:
```html
<voicecontrol>
devicetype = oven
</voicecontrol>
```
or in Device_Config in config.yaml:
```python
Device_Config:
   212:
     devicetype: 'oven'
```
Light Device types to choose from is:
_light, ac_unit, bathtub, coffemaker, dishwasher, dryer, fan, heater, kettle, media, microwave, outlet, oven, speaker, switch, vacuum, washer, waterheater, window, gate,  garage_. 

For _heater, kettle, waterheater, oven_ you can also use `merge_thermo_idx` to merge thermostat to control temperature.
```html
<voicecontrol>
devicetype = oven
merge_thermo_idx = 432
</voicecontrol>
```

Door Contact devices can choose _window, gate_ or _garage_

Selector devices can choose only _vacuum_

Issue #92 Feature request from @afrieswijk