### PR TITLE
Pidfilepath

### DIFF
--- a/config/default_config
+++ b/config/default_config
@@ -11,6 +11,8 @@ pathToLogFile: ''
 userinterface: true
 # Check for updates
 CheckForUpdates: true
+# Change pidfile name and path if needed
+PidFile: 'config/dzga.pid'
 
 # Instantly create a public HTTPS URL. Don't have to open any port on router and do not require a reverse proxy.
 # When ngrok_tunnel set to True the auth token is required to keep the tunnel alive. 

--- a/const.py
+++ b/const.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
                     
 """Constants for Google Assistant."""
-VERSION = '1.7.10'
+VERSION = '1.7.11'
 PUBLIC_URL = 'https://[your public url]'
 CONFIGFILE = 'config/config.yaml'
 LOGFILE = 'dzga.log'
 KEYFILE = 'config/smart-home-key.json'
-PIDFILE = '/var/run/dzga.pid'
 
 HOMEGRAPH_URL = "https://homegraph.googleapis.com/"
 HOMEGRAPH_SCOPE = "https://www.googleapis.com/auth/homegraph"

--- a/smarthome.py
+++ b/smarthome.py
@@ -17,7 +17,7 @@ from auth import *
 from const import (DOMOTICZ_TO_GOOGLE_TYPES, ERR_FUNCTION_NOT_SUPPORTED, ERR_PROTOCOL_ERROR, ERR_DEVICE_OFFLINE,
                    TEMPLATE, ERR_UNKNOWN_ERROR, ERR_CHALLENGE_NEEDED, DOMOTICZ_GET_ALL_DEVICES_URL, domains,
                    DOMOTICZ_GET_SETTINGS_URL, DOMOTICZ_GET_ONE_DEVICE_URL, DOMOTICZ_GET_SCENES_URL, CONFIGFILE, LOGFILE,
-                   REQUEST_SYNC_BASE_URL, REPORT_STATE_BASE_URL, ATTRS_BRIGHTNESS, ATTRS_FANSPEED, PIDFILE,
+                   REQUEST_SYNC_BASE_URL, REPORT_STATE_BASE_URL, ATTRS_BRIGHTNESS, ATTRS_FANSPEED,
                    ATTRS_THERMSTATSETPOINT, ATTRS_COLOR_TEMP, ATTRS_PERCENTAGE, VERSION, DOMOTICZ_GET_VERSION)
 from helpers import (configuration, readFile, saveFile, SmartHomeError, SmartHomeErrorNoChallenge, AogState, uptime,
                      getTunnelUrl, FILE_DIR, logger, ReportState, Auth, logfilepath)
@@ -25,9 +25,8 @@ from helpers import (configuration, readFile, saveFile, SmartHomeError, SmartHom
 DOMOTICZ_URL = configuration['Domoticz']['ip'] + ':' + configuration['Domoticz']['port']
 CREDITS = (configuration['Domoticz']['username'], configuration['Domoticz']['password'])
 
-# Travis override
-if os.environ.get('TRAVIS') != 'true':
-    pidfile = PidFile(pidname=PIDFILE)
+if 'PidFile' in configuration:
+    pidfile = PidFile(pidname=os.path.join(FILE_DIR, configuration['PidFile']))
 else:
     pidfile = PidFile('dzga')
 


### PR DESCRIPTION
Remove PidFile form const.py. Instaed add possibility to change path in config.yaml e.g:
`PidFile: 'config/dzga.pid'`
If not added to config, pypid use default path.