### PR TITLE
Update pip-requirements.txt for pychromecast

### DIFF
--- a/requirements/pip-requirements.txt
+++ b/requirements/pip-requirements.txt
@@ -9,7 +9,10 @@ urllib3>=1.25.7
 GitPython>=3.0.5
 google-auth>=1.8.1
 wheel>=0.34.2
-Jinja2==2.11.3
-PyChromecast==0.3.2
-gTTS==2.2.1
-slugify==0.0.1
+Jinja2>=2.11.3
+PyChromecast>=9.1.2
+gTTS>=2.2.1
+unicode-slugify>=0.1.3
+protobuf>=3.0.0
+zeroconf>=0.25.1
+casttube>=0.2.0


### PR DESCRIPTION
Hi @DewGew  included updates of the requirements (versions and pychromecast requirements).  Can you please publish this as new version (actual master has wrong unicode / slugify reference)? I have extensions and new functionalities available for pychromecast utilities to be put in beta after this publication.